### PR TITLE
updated tools with CSV extractor class

### DIFF
--- a/grizly/api.py
+++ b/grizly/api.py
@@ -15,6 +15,10 @@ from .core.utils import (
     get_path
 )
 
+from .core.extract import(
+    Csv
+)
+
 from .io.etl import (
     to_s3,
     read_s3,

--- a/grizly/core/extract.py
+++ b/grizly/core/extract.py
@@ -1,0 +1,79 @@
+import boto3
+import os
+import csv
+from pandas import (
+    ExcelWriter
+)
+import openpyxl
+import win32com.client as win32
+from grizly.core.utils import (
+    get_path,
+    read_config,
+    check_if_exists
+)
+from pandas import DataFrame
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
+grizly_config = read_config()
+os.environ["HTTPS_PROXY"] = grizly_config["https"]
+
+class Csv():
+    def __init__(self, config=None, engine_str:str=None):
+        if config == None:
+            self.engine_str = engine_str
+        else:
+            self.engine_str = config.engine_str
+        self.deletethis = ""
+
+    def from_sql(self, table, csv_path, schema:str=None, chunksize:int=1000):
+        engine = create_engine(self.engine_str, encoding='utf8', poolclass=NullPool)
+        conn = engine.connect().connection
+        cursor = conn.cursor()
+        sql = f"""SELECT count(*) FROM {table};"""
+        cursor.execute(sql)
+        records_count = cursor.fetchone()[0]
+        chunks = 0
+        chunks_int = records_count//chunksize
+        chunks_float = records_count/chunksize
+        if chunks_float>chunks_int:
+            chunks += chunks_int + 1
+        if chunks_float<1:
+            chunks += chunks_int + 1
+        #Header Stuff
+        if schema != None:
+            sql = f"""SELECT * FROM {schema}.{table} LIMIT 1;"""
+        else:
+            sql = f"""SELECT * FROM {table} LIMIT 1;"""
+        cursor.execute(sql)
+        column_names = [desc[0] for desc in cursor.description]
+        #Data
+        for chunk in range(chunks):
+            offset = chunk * chunksize
+            print(f"start loading {chunksize} records")
+            sql = f"""SELECT * FROM {table} LIMIT {chunksize} OFFSET {offset};"""
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+            if not rows:
+                break
+            if chunk == 0:
+                try:
+                    os.remove(csv_path)
+                except FileNotFoundError:
+                    pass
+            with open(csv_path, 'a', newline='', encoding = 'utf-8') as csvfile:
+                writer = csv.writer(csvfile, delimiter=',')
+                if chunk == 0:
+                    writer.writerow(column_names)
+                writer = csv.writer(csvfile, delimiter=',')
+                writer.writerows(rows)
+            print(f"loaded {offset + chunksize} records")
+        cursor.close()
+        conn.close()
+        return self
+
+    def from_sfdc(self):
+        pass
+    
+    def from_github(self):
+        pass

--- a/grizly/core/extract.py
+++ b/grizly/core/extract.py
@@ -1,78 +1,88 @@
-import boto3
 import os
 import csv
-from pandas import (
-    ExcelWriter
-)
-import openpyxl
-import win32com.client as win32
-from grizly.core.utils import (
-    get_path,
-    read_config,
-    check_if_exists
-)
-from pandas import DataFrame
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
-grizly_config = read_config()
-os.environ["HTTPS_PROXY"] = grizly_config["https"]
-
-class Csv():
-    def __init__(self, config=None, engine_str:str=None):
-        if config == None:
-            self.engine_str = engine_str
-        else:
-            self.engine_str = config.engine_str
-        self.deletethis = ""
-
-    def from_sql(self, table, csv_path, schema:str=None, chunksize:int=1000):
-        engine = create_engine(self.engine_str, encoding='utf8', poolclass=NullPool)
-        conn = engine.connect().connection
-        cursor = conn.cursor()
-        sql = f"""SELECT count(*) FROM {table};"""
-        cursor.execute(sql)
-        records_count = cursor.fetchone()[0]
-        chunks = 0
-        chunks_int = records_count//chunksize
-        chunks_float = records_count/chunksize
-        if chunks_float>chunks_int:
-            chunks += chunks_int + 1
-        if chunks_float<1:
-            chunks += chunks_int + 1
-        #Header Stuff
-        if schema != None:
-            sql = f"""SELECT * FROM {schema}.{table} LIMIT 1;"""
-        else:
-            sql = f"""SELECT * FROM {table} LIMIT 1;"""
-        cursor.execute(sql)
-        column_names = [desc[0] for desc in cursor.description]
-        #Data
-        for chunk in range(chunks):
-            offset = chunk * chunksize
-            print(f"start loading {chunksize} records")
-            sql = f"""SELECT * FROM {table} LIMIT {chunksize} OFFSET {offset};"""
-            cursor.execute(sql)
-            rows = cursor.fetchall()
-            if not rows:
-                break
-            if chunk == 0:
-                try:
-                    os.remove(csv_path)
-                except FileNotFoundError:
-                    pass
-            with open(csv_path, 'a', newline='', encoding = 'utf-8') as csvfile:
-                writer = csv.writer(csvfile, delimiter=',')
-                if chunk == 0:
-                    writer.writerow(column_names)
+def csv_writer(path, rows):
+    with open(path, 'a', newline='', encoding = 'utf-8') as csvfile:
+                print("writing...")
                 writer = csv.writer(csvfile, delimiter=',')
                 writer.writerows(rows)
-            print(f"loaded {offset + chunksize} records")
-        cursor.close()
-        conn.close()
+
+class Extract():
+    """
+        Writes to csv file.
+        Parameters
+        ----------
+        csv_path : string
+            Path to csv file.
+    """
+    def __init__(self, config=None, csv_path:str=None, extract_format:str = 'csv'):
+        if config == None:
+            self.csv_path = csv_path
+        else:
+            self.csv_path = config.csv_path
+    
+    def get_path(self):
+        return self.csv_path
+
+    def from_sql(self, table, engine_str, chunk_column:str=None, schema:str=None, sep='\t'):
+        """
+        Writes SQL table to csv file.
+        Parameters
+        ----------
+        sql : string
+            SQL query.
+        engine : str
+            Engine string.
+        sep : string, default '\t'
+            Separtor/delimiter in csv file.
+        """
+        engine = create_engine(engine_str, encoding='utf8', poolclass=NullPool)
+        try:
+            conn = engine.connect().connection
+        except:
+            conn = engine.connect().connection
+        cursor = conn.cursor()
+
+        if chunk_column != None:
+            sql = f"""SELECT {chunk_column} FROM {table} GROUP BY {chunk_column};"""
+            cursor.execute(sql)
+            records = [t[0] for t in cursor.fetchall()]
+
+            for chunk_column_value in records:
+                print(f"start loading {chunk_column} = {chunk_column_value} of {records}")
+                sql = f"""SELECT * FROM {table} WHERE {chunk_column}={chunk_column_value};"""
+                cursor.execute(sql)
+                rows = cursor.fetchall()
+                if extract_format == 'csv':
+                    csv_writer(self.csv_path, rows)
+                else:
+                    raise "Error format not supported"
+        else:
+            print(f"start loading records")
+            sql = f"""SELECT * FROM {table};"""
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+            if extract_format == 'csv':
+                csv_writer(self.csv_path, rows)
+            else:
+                raise "Error format not supported"
         return self
 
+    def from_qf():
+        pass
+
     def from_sfdc(self):
+        """
+        Writes Salesforce table to csv file.
+        Parameters
+        ----------
+        username : string
+        username_password : string
+        tablename : string
+        ...?
+        """
         pass
     
     def from_github(self):

--- a/grizly/core/tools.py
+++ b/grizly/core/tools.py
@@ -1,5 +1,6 @@
 import boto3
 import os
+import csv
 from pandas import (
     ExcelWriter
 )
@@ -12,9 +13,54 @@ from grizly.core.utils import (
 )
 from pandas import DataFrame
 from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
 grizly_config = read_config()
 os.environ["HTTPS_PROXY"] = grizly_config["https"]
+
+class Csv():
+    def __init__(self, config=None, engine_str:str=None):
+        if config == None:
+            self.engine_str = engine_str
+        else:
+            self.engine_str = config.engine_str
+        self.deletethis = ""
+
+    def from_sql(self, table, csv_path, schema:str=None, chunksize:int=1000):
+        engine = create_engine(self.engine_str, encoding='utf8', poolclass=NullPool)
+        conn = engine.connect().connection
+        cursor = conn.cursor()
+        sql = f"""SELECT count(*) FROM {table};"""
+        cursor.execute(sql)
+        records_count = cursor.fetchone()[0]
+        chunks = 0
+        chunks_int = records_count//chunksize
+        chunks_float = records_count/chunksize
+        if chunks_float>chunks_int:
+            chunks += chunks_int + 1
+        if chunks_float<1:
+            chunks += chunks_int + 1
+        for chunk in range(chunks):
+            offset = chunk * chunksize
+            sql = f"""SELECT * FROM {table} LIMIT {chunksize} OFFSET {offset};"""
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+            if not rows:
+                break
+            if chunk == 0:
+                os.remove(csv_path)
+            with open(csv_path, 'a', newline='', encoding = 'utf-8') as csvfile:
+                writer = csv.writer(csvfile, delimiter=',')
+                writer.writerows(rows)
+        cursor.close()
+        conn.close()
+        return self
+
+    def from_sfdc(self):
+        pass
+    
+    def from_github(self):
+        pass
 
 class Excel:
     """Class which deals with Excel files.

--- a/grizly/tests/config.py
+++ b/grizly/tests/config.py
@@ -1,0 +1,7 @@
+import os
+
+engine_str = "sqlite:///" + os.getcwd() + "\\Chinook.sqlite"
+
+csv_path = os.getcwd() + "\\fromsql_testing.csv"
+
+tests_txt_file = os.getcwd() + "\\output.txt"

--- a/grizly/tests/test_tools.py
+++ b/grizly/tests/test_tools.py
@@ -1,7 +1,7 @@
 from pandas import DataFrame
 import os
 from filecmp import cmp
-from grizly.core.tools import (
+from grizly import (
     AWS
     , Csv
 )

--- a/grizly/tests/test_tools.py
+++ b/grizly/tests/test_tools.py
@@ -3,8 +3,8 @@ import os
 from filecmp import cmp
 from grizly import (
     AWS
-    , Csv
 )
+from grizly import extract
 from grizly.tests import config
 
 def write_out(out):
@@ -30,5 +30,5 @@ def test_df_to_s3_and_s3_to_file():
     os.remove(second_file_path)
 
 def test_csv_from_sql():
-    csv = Csv(config=config).from_sql(table="artist", chunksize=100, csv_path=config.csv_path)
+    csv = extract.Csv(csv_path=config.csv_path).from_sql(table="artist", engine_str=config.engine_str, chunksize=100)
     write_out(csv.deletethis)

--- a/grizly/tests/test_tools.py
+++ b/grizly/tests/test_tools.py
@@ -3,8 +3,16 @@ import os
 from filecmp import cmp
 from grizly.core.tools import (
     AWS
+    , Csv
 )
+from grizly.tests import config
 
+def write_out(out):
+    with open(
+        config.tests_txt_file,
+        "w",
+    ) as f:
+        f.write(out)
 
 def test_df_to_s3_and_s3_to_file():
     aws = AWS(file_name='testing_aws_class.csv')
@@ -20,3 +28,7 @@ def test_df_to_s3_and_s3_to_file():
     assert cmp(first_file_path, second_file_path) == True
     os.remove(first_file_path)
     os.remove(second_file_path)
+
+def test_csv_from_sql():
+    csv = Csv(config=config).from_sql(table="artist", chunksize=100, csv_path=config.csv_path)
+    write_out(csv.deletethis)


### PR DESCRIPTION
Added an extractor class that looks like this

`Csv(config=config).from_sql(..)`

The idea is that the class is what we extract. There are quite few things to fix but I have also created the following test

```
def test_csv_from_sql():
    csv = Csv(config=config).from_sql(table="artist", chunksize=100, csv_path=config.csv_path)
    write_out(csv.deletethis)
```

With the following config:

```
import os
engine_str = "sqlite:///" + os.getcwd() + "\\Chinook.sqlite"
csv_path = os.getcwd() + "\\fromsql_testing.csv"
```

By using the Chinook.sqlite database we don't need to pass local configs to the public grizly repo and tests should be working on all local setups.

If you read the test you can understand how this works. Now next we need to add

* from_sfdc
* from_github
