### PR TITLE
Status table and notifications enhancements

### DIFF
--- a/grizly/orchestrate.py
+++ b/grizly/orchestrate.py
@@ -142,7 +142,7 @@ class Listener:
 
 
 
-    def get_table_last_refresh(self):
+    def get_table_refresh_date(self):
 
         sql = f"SELECT {self.field} FROM {self.schema}.{self.table} ORDER BY {self.field} DESC LIMIT 1;"
 
@@ -161,16 +161,23 @@ class Listener:
         return last_data_refresh
 
 
-    def should_trigger(self, table_last_refresh):
+    def should_trigger(self, table_refresh_date):
 
         if self.trigger == "default":
-            # will trigger on day change
-            if (not self.last_data_refresh) or (table_last_refresh != self.last_data_refresh):
+            # first run
+            if not self.last_data_refresh:
+                return True
+            # the table ran previously, but now the refresh date is None
+            # this mean the table is being cleared in preparation for update
+            if not table_refresh_date:
+                return False
+            # trigger on day change
+            if table_refresh_date != self.last_data_refresh:
                 return True
 
         elif isinstance(self.trigger, Schedule):
             next_check_on = datetime.date(self.trigger.next_run)
-            if next_check_on == table_last_refresh:
+            if next_check_on == table_refresh_date:
                 return True
         if self.trigger == "fiscal day":
             # date_fiscal_day = to_fiscal(table_last_refresh, "day")
@@ -193,7 +200,7 @@ class Listener:
         self.logger.info(f"Listening for changes in {self.table}...")
 
         try:
-            last_data_refresh = self.get_table_last_refresh()
+            last_data_refresh = self.get_table_refresh_date()
         except:
             self.logger.exception(f"Connection or query error when connecting to {self.db}")
             last_data_refresh = None

--- a/grizly/orchestrate.py
+++ b/grizly/orchestrate.py
@@ -163,7 +163,7 @@ class Listener:
 
         if isinstance(last_data_refresh, str):
             # try casting to date
-            last_data_refresh = datetime.datetime.strptime("2019-11-26", "%Y-%m-%d")
+            last_data_refresh = datetime.datetime.strptime(last_data_refresh, "%Y-%m-%d")
 
         if isinstance(last_data_refresh, datetime.datetime):
             last_data_refresh = datetime.datetime.date(last_data_refresh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,9 @@ SQLAlchemy>=1.3.5
 sqlparse>=0.3.0
 xlrd>=1.2.0
 XlsxWriter>=1.1.8
-xlwings>=0.15.8
 xlwt>=1.3.0
 simple-salesforce>=0.74.2
-dask>=2.1.0
+dask[complete]
 exchangelib>=2.0.1
 pendulum>=2.0.5
 croniter>=0.3.29


### PR DESCRIPTION
- added env, error_value, and error_type columns to status table
- moved status table to the new Redshift instance and database
- status is now reported at `Runner` level; as a temporaty workaround, the user needs to pass `local=True` to `Workflow.run()` in order for the a workflow run to produce a status record
- added type checking to `Listener`'s  `last_date_refresh` field; accepted types are now `int` and `datetime.date` (Listener attempts conversion to these formats before raising `TypeError`)
- improved notification in case of workflow error; it now displays the full traceback instead of only error name
- notifications no longer include log file as attachment