### PR TITLE
Fixed bugs related to QFrame, added QFrame.sum() method

### DIFF
--- a/grizly/etl.py
+++ b/grizly/etl.py
@@ -255,6 +255,7 @@ def csv_to_s3(csv_path, s3_key: str = None, keep_csv=True, bucket: str = None):
     bucket_name = bucket if bucket else "teis-data"
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)
+    s3_key = s3_key or ""
 
     # if s3_name[-4:] != '.csv': s3_name = s3_name + '.csv'
 

--- a/grizly/tools/s3.py
+++ b/grizly/tools/s3.py
@@ -230,7 +230,7 @@ class S3:
         --------
         >>> file_dir=get_path('acoe_projects', 'analytics_project_starter', '01_workflows')
         >>> s3 = S3('test_table.csv', s3_key='analytics_project_starter/test/', file_dir=file_dir)
-        >>> s3.from_file()
+        >>> s3 = s3.from_file()
         'test_table.csv' uploaded to 'acoe-s3' bucket as 'analytics_project_starter/test/test_table.csv'
         """
         file_path = os.path.join(self.file_dir, self.file_name)
@@ -303,7 +303,7 @@ class S3:
         --------
         >>> from pandas import DataFrame
         >>> df = DataFrame({'col1': [1, 2], 'col2': [3, 4]})
-        >>> S3('test.csv', 'bulk/', file_dir=r'C:\\Users').from_df(df, keep_file=False)
+        >>> s3 = S3('test.csv', 'bulk/', file_dir=r'C:\\Users').from_df(df, keep_file=False)
         DataFrame saved in 'C:\\Users\\test.csv'
         'test.csv' uploaded to 'acoe-s3' bucket as 'bulk/test.csv'
         'C:\\Users\\test.csv' has been removed


### PR DESCRIPTION
Fixed `.__getitem__` method which caused errors in `.agg` method and added `.sum()` which sums all the fields that are not grouped - later we can do the same with other aggregations

Example (two ways of aggregate with sum):
```python
>>> qf = QFrame().read_dict(data = {'select': {'fields': {'CustomerId': {'type': 'dim'}, 'Sales': {'type': 'num'}, 'Orders': {'type': 'num'}}, 'schema': 'schema', 'table': 'table'}})
>>> qf1 = qf.copy()
>>> qf1 = qf1.groupby(['CustomerId'])['Sales', 'Orders'].agg('sum')
>>> print(qf1)
SELECT CustomerId,
    sum(Sales) AS Sales,
    sum(Orders) AS Orders
FROM schema.table
GROUP BY CustomerId

>>> qf2 = qf.copy()
>>> qf2 = qf2.groupby(['CustomerId']).sum()
>>> print(qf2)
SELECT CustomerId,
    sum(Sales) AS Sales,
    sum(Orders) AS Orders
FROM schema.table
GROUP BY CustomerId
```